### PR TITLE
Added a scoping around the avatar

### DIFF
--- a/core-drag-drop.html
+++ b/core-drag-drop.html
@@ -9,16 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 
-<style>
-  core-drag-avatar {
-    position: fixed;
-    left: 0;
-    top: 0;
-    display: block;
-    pointer-events: none;
-  }
-</style>
-
 <!--
 @group Polymer Core Elements
 @element core-drag-drop
@@ -26,6 +16,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <polymer-element name="core-drag-drop">
+  <template>
+    <style>
+      core-drag-avatar {
+        position: fixed;
+        left: 0;
+        top: 0;
+        display: block;
+        pointer-events: none;
+      }
+    </style>
+
+    <div id="avatarcontent"></div>
+  </template>
+  
 <script>
 (function() {
   var avatar;
@@ -39,7 +43,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     ready: function() {
       if (!avatar) {
         avatar = document.createElement('core-drag-avatar');
-        document.body.appendChild(avatar);
+        this.$.avatarcontent.appendChild(avatar);
       }
       this.avatar = avatar;
       this.dragging = false;


### PR DESCRIPTION
This make it possible to use the `<core-drag-drop>` element in different other components and style them for each component based on a deep or shadow pseudo selector. This was not possible before this patch, because the global namespace was used with `document.body.appendChild(avatar)`. Now the avatar is appended to the components shadow dom. I think that's much cleaner.

For example, before this you could style the avatar in the following way:

```
core-drag-avatar {
  border: 1px grey dotted;
  opacity: 0.8;
}
```

The problem here is that all `core-drag-avatar`s are equally styled.

Now you can use it in this way (when you want to style it globally):

```
html /deep/ core-drag-drop::shadow core-drag-avatar {
  border: 1px grey dotted;
  opacity: 0.8;
}
```

Or you can use it in sub-components that make use of `<core-drag-drop>`:

```
core-drag-drop::shadow core-drag-avatar {
  border: 1px grey dotted;
  opacity: 0.8;
}
```
